### PR TITLE
Add support for Teensy. 

### DIFF
--- a/EventManager/EventManager.cpp
+++ b/EventManager/EventManager.cpp
@@ -124,6 +124,28 @@ namespace
         uint32_t    mSavedInterruptState;
     };
 
+#elif defined( CORE_TEENSY )
+    
+    class SuppressInterrupts
+    {
+    public:
+        
+        //Reference: https://www.pjrc.com/teensy/interrupts.html
+        //Backup the interrupt enable state and restore it
+        SuppressInterrupts() {
+            sreg_backup = SREG;     /* save interrupt enable/disable state */
+            cli();                  /* disable the global interrupt */
+        }
+        
+        ~SuppressInterrupts() {
+            SREG = sreg_backup;     /* restore interrupt state */
+        }
+        
+    private:
+        
+        unsigned char sreg_backup;
+    };
+    
 #else
 
 #error "Unknown microcontroller:  Need to implement class SuppressInterrupts for this microcontroller."


### PR DESCRIPTION
Using CORE_TEENSY macro. Backup interrupt state and restore it later according to Teensy interrupts reference page. Tested with Teensy 3.1.

Thanks for the fantastic library Igor! Very much enjoying it. Hereby I offer this pull request for you to consider.

Best regards,
Arne.
