### PR TITLE
Added critical section and IRAM attribute for ESP32

### DIFF
--- a/EventManager/EventManager.h
+++ b/EventManager/EventManager.h
@@ -37,6 +37,14 @@
 
 #include <Arduino.h>
 
+// For ESP32, interrupt handling routines (and any functions called from them) should be placed in IRAM
+// This define allows an attribute to be specified for queueEvent() under these circumstances
+#if defined ( ESP32 )
+#define ISR_ATTR IRAM_ATTR
+#else
+#define ISR_ATTR
+#endif
+
 // Size of the listener list.  Adjust as appropriate for your application.
 // Requires a total of sizeof(*f())+sizeof(int)+sizeof(boolean) bytes of RAM for each unit of size
 #ifndef EVENTMANAGER_LISTENER_LIST_SIZE


### PR DESCRIPTION
@igormiktor 

Here is a pull request. I tried to have as light a touch as possible in the existing code. You'll see that an IRAM attribute is required for any interrupt handlers or functions called from them.

I modified the WithInterrupts example, but for me it's a cpp file as I program in PlatformIO, so I'm going to put the source for that in the Issue.